### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,6 @@
 name: Mypy Type Check (uv + pyproject.toml)
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,6 @@
 name: Ruff
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Rudertier/medisana_blood_pressure/security/code-scanning/10](https://github.com/Rudertier/medisana_blood_pressure/security/code-scanning/10)

To resolve this issue, the workflow should explicitly declare the minimal required permissions for the `GITHUB_TOKEN` by adding a `permissions` block. Since this workflow only reads repository contents to run static analysis, the only needed permission is `contents: read`. The `permissions` key can be set at the workflow root (applies to all jobs unless overridden) or at the job level; the root level is preferred for simple workflows. Edit `.github/workflows/ruff.yml` and insert the following under the `name:` line (and before `on:`):  
```yaml
permissions:
  contents: read
```
No additional imports, dependencies, or method definitions are required—this is purely a configuration edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
